### PR TITLE
BREAKING: remove the quant+aot_inductor options

### DIFF
--- a/src/alma/conversions/options/export_aotinductor.py
+++ b/src/alma/conversions/options/export_aotinductor.py
@@ -73,32 +73,3 @@ def get_AOTInductor_lowered_model_forward_call(
         forward = torch._export.aot_load(so_path, device=device.type)
 
     return forward
-
-
-def get_quant_export_aot_inductor_forward_call(
-    model,
-    data: torch.Tensor,
-    device: torch.device,
-    int_or_dequant_op: Literal["int", "dequant"],
-    run_decompositions: bool,
-) -> Callable:
-    """
-    Get the forward call function for the exported quantized model using AOTInductor.
-    We first produce the quantized exported model, then call AOtInductor to lower it.
-
-    Inputs:
-    - model (torch.nn.Module): The model to export
-    - data (torch.Tensor): Sample data to feed through the model for tracing.
-    - device (torch.device): The device we are loading the AOTInductor-lowered model to.
-    - int_or_dequant_op (Literal["int", "dequant"]): do we use integer arithmetic operations on
-            quantized layers, or do we dequantize just prior to the op
-    - run_decompositions (bool): do we, after all of our processing, re-export the model and run
-            `run_decompositions`?
-
-    Outputs:
-    - forward (Callable): The forward call function for the model.
-    """
-
-    model = get_quant_exported_model(model, data, int_or_dequant_op, run_decompositions)
-    forward = get_export_aot_inductor_forward_call(model, data, device)
-    return forward

--- a/src/alma/conversions/select.py
+++ b/src/alma/conversions/select.py
@@ -48,13 +48,9 @@ MODEL_CONVERSION_OPTIONS = {
     11: "COMPILE_OPENXLA",
     12: "COMPILE_TVM",
     13: "EXPORT+AI8WI8_FLOAT_QUANTIZED",
-    14: "EXPORT+AI8WI8_FLOAT_QUANTIZED+AOT_INDUCTOR",
     15: "EXPORT+AI8WI8_FLOAT_QUANTIZED+RUN_DECOMPOSITION",
-    16: "EXPORT+AI8WI8_FLOAT_QUANTIZED+RUN_DECOMPOSITION+AOT_INDUCTOR",
     17: "EXPORT+AI8WI8_STATIC_QUANTIZED",
-    18: "EXPORT+AI8WI8_STATIC_QUANTIZED+AOT_INDUCTOR",
     19: "EXPORT+AI8WI8_STATIC_QUANTIZED+RUN_DECOMPOSITION",
-    20: "EXPORT+AI8WI8_STATIC_QUANTIZED+RUN_DECOMPOSITION+AOT_INDUCTOR",
     21: "EXPORT+AOT_INDUCTOR",
     22: "EXPORT+COMPILE_CUDAGRAPH",
     23: "EXPORT+COMPILE_INDUCTOR_DEFAULT",
@@ -154,20 +150,6 @@ def select_forward_call_function(
                 model, data, int_or_dequant_op="dequant", run_decompositions=False
             )
 
-        case "EXPORT+AI8WI8_STATIC_QUANTIZED+AOT_INDUCTOR":
-            forward = get_quant_export_aot_inductor_forward_call(
-                model, data, device, int_or_dequant_op="int", run_decompositions=False
-            )
-
-        case "EXPORT+AI8WI8_FLOAT_QUANTIZED+AOT_INDUCTOR":
-            forward = get_quant_export_aot_inductor_forward_call(
-                model,
-                data,
-                device,
-                int_or_dequant_op="dequant",
-                run_decompositions=False,
-            )
-
         case "EXPORT+AI8WI8_STATIC_QUANTIZED+RUN_DECOMPOSITION":
             # The difference with training (i.e. inference=False) is that at the end we re-run
             # torch.export and then run `run_decompositions`, with the hope it might shorted the graph
@@ -179,20 +161,6 @@ def select_forward_call_function(
         case "EXPORT+AI8WI8_FLOAT_QUANTIZED+RUN_DECOMPOSITION":
             forward = get_quant_exported_forward_call(
                 model, data, int_or_dequant_op="dequant", run_decompositions=True
-            )
-
-        case "EXPORT+AI8WI8_STATIC_QUANTIZED+RUN_DECOMPOSITION+AOT_INDUCTOR":
-            forward = get_quant_export_aot_inductor_forward_call(
-                model, data, device, int_or_dequant_op="int", run_decompositions=True
-            )
-
-        case "EXPORT+AI8WI8_FLOAT_QUANTIZED+RUN_DECOMPOSITION+AOT_INDUCTOR":
-            forward = get_quant_export_aot_inductor_forward_call(
-                model,
-                data,
-                device,
-                int_or_dequant_op="dequant",
-                run_decompositions=True,
             )
 
         ##################


### PR DESCRIPTION
They're not supported by aot (at least via that API). I'll try get it working via torch.compile, but those conversion methods have never worked, so should remove them.