### PR TITLE
Optimum quanto + multi-processing

### DIFF
--- a/src/alma/benchmark_model.py
+++ b/src/alma/benchmark_model.py
@@ -9,8 +9,8 @@ from .benchmark import benchmark
 from .conversions.select import MODEL_CONVERSION_OPTIONS
 from .dataloader.create import create_single_tensor_dataloader
 from .utils.checks import check_consistent_batch_size, check_inputs
-from .utils.times import inference_time_benchmarking  # should we use this?
 from .utils.processing import process_wrapper
+from .utils.times import inference_time_benchmarking  # should we use this?
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/src/alma/conversions/options/compile.py
+++ b/src/alma/conversions/options/compile.py
@@ -5,8 +5,8 @@ from typing import Callable, Dict, Literal, Union
 import torch
 import torch._dynamo
 import torch.fx as fx
-from torch.export.exported_program import ExportedProgram
 from torch._dynamo.eval_frame import OptimizedModule
+from torch.export.exported_program import ExportedProgram
 
 from ...utils.setup_logging import suppress_output
 from .utils.checks.type import check_model_type

--- a/src/alma/conversions/options/optimum_quanto.py
+++ b/src/alma/conversions/options/optimum_quanto.py
@@ -1,13 +1,13 @@
-from optimum.quanto import quantize, freeze
-from optimum.quanto.tensor.qtype import qtype, qtypes
 import logging
-from typing import Union, Optional
+from typing import Optional, Union
 
-from torch._dynamo.eval_frame import OptimizedModule
 import torch
+from optimum.quanto import freeze, quantize
+from optimum.quanto.tensor.qtype import qtype, qtypes
+from torch._dynamo.eval_frame import OptimizedModule
 
-from .utils.checks.type import check_model_type
 from .compile import get_compiled_model
+from .utils.checks.type import check_model_type
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -94,7 +94,7 @@ def get_optimum_quant_compiled_model(
     - backend (str): the backend for torch.compile. Default is torch inductor.
 
     Returns:
-    - model (OptimizedModule): the HuggingFace Optimum Quanto quantized, and then torch.compiled, model. 
+    - model (OptimizedModule): the HuggingFace Optimum Quanto quantized, and then torch.compiled, model.
     """
     model = get_optimum_quanto_model(model, data, weights, activations)
 

--- a/src/alma/conversions/select.py
+++ b/src/alma/conversions/select.py
@@ -4,22 +4,20 @@ from pathlib import Path
 from typing import Any, Callable
 
 import torch
-
 from optimum.quanto import (
-    qint8,
-    qint4,
-    qint2,
-    qfloat8_e5m2,
-    qfloat8_e4m3fnuz,
     qfloat8_e4m3fn,
+    qfloat8_e4m3fnuz,
+    qfloat8_e5m2,
+    qint2,
+    qint4,
+    qint8,
 )
+
 from .options.compile import (
     get_compiled_forward_call_eager_fallback,
     get_compiled_model_forward_call,
 )
-from .options.export_aotinductor import (
-    get_export_aot_inductor_forward_call,
-)
+from .options.export_aotinductor import get_export_aot_inductor_forward_call
 from .options.export_compile import (
     get_export_compiled_forward_call,
     get_export_compiled_forward_call_eager_fallback,
@@ -27,21 +25,20 @@ from .options.export_compile import (
 from .options.export_eager import get_export_eager_forward_call
 from .options.export_quant import get_quant_exported_forward_call
 from .options.fake_quant import get_fake_quantized_model_forward_call
+from .options.jit_trace import get_jit_traced_model_forward_call
 from .options.onnx import get_onnx_dynamo_forward_call, get_onnx_forward_call
 from .options.optimum_quanto import (
-    get_optimum_quanto_forward_call,
     get_optimum_quant_model_compiled_forward_call,
+    get_optimum_quanto_forward_call,
 )
 from .options.quant_convert import get_converted_quantized_model_forward_call
+from .options.torchscript import get_torch_scripted_model_forward_call
 from .options.utils.checks.imports import (
     check_onnxrt,
     check_openxla,
     check_tensort,
     check_tvm,
 )
-from .options.jit_trace import get_jit_traced_model_forward_call
-from .options.torchscript import get_torch_scripted_model_forward_call
-
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -325,7 +322,11 @@ def select_forward_call_function(
 
         case "OPTIMIM_QUANTO_Wf8E5M2+COMPILE_CUDAGRAPHS":
             forward = get_optimum_quant_model_compiled_forward_call(
-                model, data, weights=qfloat8_e5m2, activations=None, backend="cudagraphs"
+                model,
+                data,
+                weights=qfloat8_e5m2,
+                activations=None,
+                backend="cudagraphs",
             )
 
         case _:

--- a/src/alma/utils/processing.py
+++ b/src/alma/utils/processing.py
@@ -1,13 +1,17 @@
 import multiprocessing as mp
 from multiprocessing import Process, Queue
+from typing import Any, Callable, Union
+
 import torch
-from typing import Any, Union, Callable
 
 if torch.cuda.is_available():
     # Set the start method to 'spawn' at the beginning of your script
-    mp.set_start_method('spawn', force=True)
+    mp.set_start_method("spawn", force=True)
 
-def run_benchmark_process(benchmark_func: Callable, args: tuple, kwargs: dict, result_queue: Queue) -> None:
+
+def run_benchmark_process(
+    benchmark_func: Callable, args: tuple, kwargs: dict, result_queue: Queue
+) -> None:
     """
     Helper function to run the benchmark in a separate process.
 
@@ -20,7 +24,10 @@ def run_benchmark_process(benchmark_func: Callable, args: tuple, kwargs: dict, r
     result = benchmark_func(*args, **kwargs)
     result_queue.put(result)
 
-def process_wrapper(benchmark_func: Callable, *args: Any, **kwargs: Any) -> Union[Any, None]:
+
+def process_wrapper(
+    benchmark_func: Callable, *args: Any, **kwargs: Any
+) -> Union[Any, None]:
     """
     Wrapper to run benchmark in a fresh process and return its results. This allows us
     to run different conversion methods (whose imports may affect the glocal state of PyTorch)
@@ -54,8 +61,7 @@ def process_wrapper(benchmark_func: Callable, *args: Any, **kwargs: Any) -> Unio
 
     # Start process
     p = Process(
-        target=run_benchmark_process,
-        args=(benchmark_func, args, kwargs, result_queue)
+        target=run_benchmark_process, args=(benchmark_func, args, kwargs, result_queue)
     )
     p.start()
     p.join()


### PR DESCRIPTION
- Adds optimum quanto options.
- Adds a multi-processing wrapper around each benchmark call, so that each benchmark call happens at a blank slate. It;s good for making everything work, but ugly for debugging / setting breakpoints. But maybe we use logging as a standin like most multi-processing environments do?