### PR TITLE
config-controlled optional multiprocessing and fast failing

### DIFF
--- a/examples/linear/benchmark_random_tensor.py
+++ b/examples/linear/benchmark_random_tensor.py
@@ -34,6 +34,9 @@ def main() -> None:
     config = {
         "n_samples": args.n_samples,
         "batch_size": args.batch_size,
+        "multiprocessing": True,  # If True, we test each method in its own isolated environment,
+        # which helps keep methods from contaminating the global torch state
+        "fail_fast": False,  # If False, we fail gracefully and keep testing other methods
     }
 
     # Benchmark the model

--- a/examples/mnist/benchmark_random_tensor.py
+++ b/examples/mnist/benchmark_random_tensor.py
@@ -33,6 +33,9 @@ def main() -> None:
     config = {
         "n_samples": args.n_samples,
         "batch_size": args.batch_size,
+        "multiprocessing": True,  # If True, we test each method in its own isolated environment,
+        # which helps keep methods from contaminating the global torch state
+        "fail_fast": False,  # If False, we fail gracefully and keep testing other methods
     }
 
     # Benchmark the model

--- a/examples/mnist/benchmark_with_dataloader.py
+++ b/examples/mnist/benchmark_with_dataloader.py
@@ -46,6 +46,9 @@ def main() -> None:
     config = {
         "n_samples": args.n_samples,
         "batch_size": args.batch_size,
+        "multiprocessing": True,  # If True, we test each method in its own isolated environment,
+        # which helps keep methods from contaminating the global torch state
+        "fail_fast": False,  # If False, we fail gracefully and keep testing other methods
     }
 
     # Benchmark the model using the provided data loader.


### PR DESCRIPTION
Via the config, we can specify if we want multi-processing, and if we want to fail quickly. It gives people more control over how they want it to run.
multi-processing defaults to True, and failing quickly defaults to False (i.e. fail gracefully is default).