### PR TITLE
Bug: Use multiprocess when on mac, and multiprocessing otherwise

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ onnx==1.17.0
 onnxruntime===1.18.0
 onnxruntime-gpu===1.18.0
 torch-tensorrt==2.5.0
+multiprocess==0.70.17
 nvidia-modelopt[torch,onnx]==0.21.0
 optimum-quanto==0.2.6
 onnxscript==0.1.0.dev20241212

--- a/src/alma/utils/multiprocessing/multiprocessing.py
+++ b/src/alma/utils/multiprocessing/multiprocessing.py
@@ -1,4 +1,3 @@
-import multiprocessing as mp
 import traceback
 from multiprocessing import Process, Queue
 from typing import Any, Callable, Union
@@ -7,6 +6,11 @@ import torch
 
 from .traceback import get_next_line_info
 
+# MPS requires the `multiprocess` package
+if torch.backends.mps.is_available():
+    import multiprocess as mp
+else:
+    import multiprocessing as mp
 
 def run_benchmark_process(
     formatted_stacktrace: str,


### PR DESCRIPTION
fix cpu fallback on MPS with multiprocessing issue by using multiprocess branch of multiprocessing when on Mac. See this [comment](https://github.com/saifhaq/alma/pull/97#issuecomment-2569909537) for motivation.