### PR TITLE
Float16 compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,29 @@ Below is a table summarizing the currently supported conversion options and thei
   | 46  |  COMPILE_INDUCTOR_MAX_AUTOTUNE+<br>TORCHAO_AUTOQUANT_NONDEFAULT | GPU  | torch.compile + torchao |
   | 47  |  COMPILE_CUDAGRAPHS+<br>TORCHAO_AUTOQUANT_DEFAULT               | GPU (CUDA) | torch.compile + torchao |
   | 48  |  COMPILE_INDUCTOR_MAX_AUTOTUNE+<br>TORCHAO_QUANT_I4_WEIGHT_ONLY | GPU (requires bf16 support)  | torch.compile + torchao |
-  | 49  |  TORCHAO_QUANT_I4_WEIGHT_ONLY                               | GPU (requires bf16 support) | torchao |
-
+  | 49  |  TORCHAO_QUANT_I4_WEIGHT_ONLY                                  | GPU (requires bf16 support) | torchao |
+  | 50  |  FP16+COMPILE_CUDAGRAPHS                                       | GPU (CUDA) | PyTorch + torch.compile |
+  | 51  |  FP16+COMPILE_INDUCTOR_DEFAULT                                 | CPU, MPS, GPU | PyTorch + torch.compile |
+  | 52  |  FP16+COMPILE_INDUCTOR_REDUCE_OVERHEAD                         | CPU, MPS, GPU | PyTorch + torch.compile |
+  | 53  |  FP16+COMPILE_INDUCTOR_MAX_AUTOTUNE                            | CPU, MPS, GPU | PyTorch + torch.compile |
+  | 54  |  FP16+COMPILE_INDUCTOR_EAGER_FALLBACK                          | CPU, MPS, GPU | PyTorch + torch.compile |
+  | 55  |  FP16+COMPILE_ONNXRT                                           | CPU, MPS, GPU | PyTorch + torch.compile + ONNXRT |
+  | 56  |  FP16+COMPILE_OPENXLA                                          | XLA_GPU       | PyTorch + torch.compile + OpenXLA |
+  | 57  |  FP16+COMPILE_TVM                                              | CPU, MPS, GPU | PyTorch + torch.compile + Apache TVM |
+  | 58  |  FP16+COMPILE_TENSORRT                                         | GPU (CUDA)    | PyTorch + torch.compile + NVIDIA TensorRT |
+  | 59  |  FP16+COMPILE_OPENVINO                                         | CPU (Intel)   | PyTorch + torch.compile + OpenVINO |
+  | 60  |  FP16+EXPORT+COMPILE_CUDAGRAPHS                                | GPU (CUDA)    | torch.export + torch.compile |
+  | 61  |  FP16+EXPORT+COMPILE_INDUCTOR_DEFAULT                          | CPU, MPS, GPU | torch.export + torch.compile |
+  | 62  |  FP16+EXPORT+COMPILE_INDUCTOR_REDUCE_OVERHEAD                  | CPU, MPS, GPU | torch.export + torch.compile |
+  | 63  |  FP16+EXPORT+COMPILE_INDUCTOR_MAX_AUTOTUNE                     | CPU, MPS, GPU | torch.export + torch.compile |
+  | 64  |  FP16+EXPORT+COMPILE_INDUCTOR_DEFAULT_EAGER_FALLBACK           | CPU, MPS, GPU | torch.export + torch.compile |
+  | 65  |  FP16+EXPORT+COMPILE_ONNXRT                                    | CPU, MPS, GPU | torch.export + torch.compile + ONNXRT |
+  | 66  |  FP16+EXPORT+COMPILE_OPENXLA                                   | XLA_GPU       | torch.export + torch.compile + OpenXLA |
+  | 67  |  FP16+EXPORT+COMPILE_TVM                                       | CPU, MPS, GPU | torch.export + torch.compile + Apache TVM |    
+  | 68  |  FP16+EXPORT+COMPILE_TENSORRT                                  | GPU (CUDA)    | torch.export + torch.compile + NVIDIA TensorRT |
+  | 69  |  FP16+EXPORT+COMPILE_OPENVINO                                  | CPU (Intel)   | torch.export + torch.compile + OpenVINO |
+  | 70  |  FP16+JIT_TRACE                                                | CPU, MPS, GPU | PyTorch   |
+  | 71  |  FP16+TORCH_SCRIPT                                             | CPU, MPS, GPU | PyTorch   |
 
 
 These conversion options are also all hard-coded in the [conversion options](src/alma/conversions/conversion_options.py)

--- a/examples/mnist/mem_efficient_benchmark_rand_tensor.py
+++ b/examples/mnist/mem_efficient_benchmark_rand_tensor.py
@@ -58,9 +58,9 @@ def main() -> None:
     config = BenchmarkConfig(
         n_samples=args.n_samples,
         batch_size=args.batch_size,
-        multiprocessing=True,  # If True, we test each method in its own isolated environment,
+        multiprocessing=False,  # If True, we test each method in its own isolated environment,
         # which helps keep methods from contaminating the global torch state
-        fail_on_error=False,  # If False, we fail gracefully and keep testing other methods
+        fail_on_error=True,  # If False, we fail gracefully and keep testing other methods
         # Device options:
         allow_device_override=not args.no_device_override,  # Allow device override for device-specific conversions
         allow_cuda=not args.no_cuda,  # True allows CUDA as an override option

--- a/src/alma/benchmark/benchmark.py
+++ b/src/alma/benchmark/benchmark.py
@@ -79,9 +79,10 @@ def benchmark(
         )
     else:
         # If a data loader is provided, we check that the data dtype matches the conversion dtype
+        data = get_sample_data(data_loader, device)
         assert (
-            data_loader.dataset.tensor.dtype == conversion.data_dtype
-        ), "The data loader dtype does not match the conversion dtype"
+            data.dtype == conversion.data_dtype
+        ), f"The data loader dtype ({data.dtype}) does not match the conversion dtype ({conversion.data_dtype})."
 
     # Send the model to device
     model = model.to(device)

--- a/src/alma/benchmark/benchmark.py
+++ b/src/alma/benchmark/benchmark.py
@@ -7,15 +7,15 @@ import torch._dynamo
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-from ..conversions.select import select_forward_call_function
 from ..conversions.conversion_options import ConversionOption
+from ..conversions.select import select_forward_call_function
 from ..dataloader.create import create_single_tensor_dataloader
 from ..utils.data import get_sample_data
 from ..utils.multiprocessing import benchmark_error_handler
 from ..utils.times import inference_time_benchmarking  # should we use this?
+from .benchmark_config import BenchmarkConfig
 from .log import log_results
 from .warmup import warmup
-from .benchmark_config import BenchmarkConfig
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/src/alma/benchmark/benchmark.py
+++ b/src/alma/benchmark/benchmark.py
@@ -143,6 +143,7 @@ def benchmark(
         "batch_size": data.shape[0],
         "throughput": throughput,
         "status": "success",
+        "data_dtype": conversion.data_dtype,
     }
     if logger.root.level <= logging.DEBUG:
         log_results(result)

--- a/src/alma/benchmark/log.py
+++ b/src/alma/benchmark/log.py
@@ -62,13 +62,14 @@ def log_results(
     None
     """
     display_function(f"Device: {results['device']}")
-    display_function(f"Total elapsed time: {results['total_elapsed_time']:.4f} seconds")
+    display_function(f"Total elapsed time: {results['total_elapsed_time']:.6f} seconds")
     display_function(
-        f"Total inference time (model only): {results['total_inf_time']:.4f} seconds"
+        f"Total inference time (model only): {results['total_inf_time']:.6f} seconds"
     )
     display_function(
         f"Total samples: {results['total_samples']} - Batch size: {results['batch_size']}"
     )
+    display_function(f"Data dtype: {results['data_dtype']}")
     display_function(f"Throughput: {results['throughput']:.2f} samples/second")
 
 

--- a/src/alma/benchmark_model.py
+++ b/src/alma/benchmark_model.py
@@ -11,7 +11,6 @@ from .conversions.conversion_options import (
     ConversionOption,
     mode_str_to_conversions,
 )
-from .dataloader.create import create_single_tensor_dataloader
 from .utils.checks import check_consistent_batch_size, check_inputs
 from .utils.device import setup_device
 from .utils.multiprocessing import benchmark_process_wrapper
@@ -89,17 +88,6 @@ def benchmark_model(
     multiprocessing: bool = config.multiprocessing
     fail_on_error: bool = config.fail_on_error
 
-    # Creates a dataloader with random data, of the same size as the input data sample
-    # If the data_loader has been provided by the user, we use that one
-    if not isinstance(data_loader, DataLoader):
-        data_loader = create_single_tensor_dataloader(
-            tensor_size=data.size(),
-            num_tensors=n_samples,
-            random_type="normal",
-            random_params={"mean": 0.0, "std": 2.0},
-            batch_size=batch_size,
-        )
-
     all_results: Dict[str, Dict[str, Any]] = {}
 
     for conversion_option in conversions:
@@ -127,9 +115,10 @@ def benchmark_model(
             benchmark,
             device,
             model,
-            conversion_mode,
+            config,
+            conversion_option,
+            data,
             data_loader,
-            n_samples,
         )
         all_results[conversion_mode] = result
 

--- a/src/alma/conversions/conversion_options.py
+++ b/src/alma/conversions/conversion_options.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Union
-import torch
 
+import torch
 from pydantic import BaseModel, Field, validator
 
 
@@ -22,11 +22,10 @@ class ConversionOption(BaseModel):
         description="Optional override for the target device, e.g., 'CPU', 'CUDA', etc.",
     )
     data_dtype: Optional[torch.dtype] = Field(  # Specify the type hint correctly
-        default=torch.float32,
-        description="The data type of the input data."
+        default=torch.float32, description="The data type of the input data."
     )
 
-    @validator('data_dtype', pre=True)
+    @validator("data_dtype", pre=True)
     def validate_dtype(cls, v):
         if v is None:
             return None
@@ -35,7 +34,7 @@ class ConversionOption(BaseModel):
             return getattr(torch, v)
         if isinstance(v, torch.dtype):
             return v
-        raise ValueError(f'Invalid dtype: {v}')
+        raise ValueError(f"Invalid dtype: {v}")
 
 
 # Predefined conversion options for benchmarking
@@ -100,23 +99,58 @@ MODEL_CONVERSION_OPTIONS: dict[int, ConversionOption] = {
         mode="COMPILE_INDUCTOR_MAX_AUTOTUNE+TORCHAO_QUANT_I4_WEIGHT_ONLY"
     ),  # Requires bf16 suuport
     49: ConversionOption(mode="TORCHAO_QUANT_I4_WEIGHT_ONLY"),  # Requires bf16 support
-    50: ConversionOption(mode="FP16+COMPILE_CUDAGRAPHS", device_override="CUDA", data_dtype=torch.float16),
-    51: ConversionOption(mode="FP16+COMPILE_INDUCTOR_DEFAULT", data_dtype=torch.float16),
-    52: ConversionOption(mode="FP16+COMPILE_INDUCTOR_REDUCE_OVERHEAD", data_dtype=torch.float16),
-    53: ConversionOption(mode="FP16+COMPILE_INDUCTOR_MAX_AUTOTUNE", data_dtype=torch.float16),
-    54: ConversionOption(mode="FP16+COMPILE_INDUCTOR_EAGER_FALLBACK", data_dtype=torch.float16),
-    55: ConversionOption(mode="FP16+COMPILE_ONNXRT", device_override="CUDA", data_dtype=torch.float16),
-    56: ConversionOption(mode="FP16+COMPILE_OPENXLA", device_override="XLA_GPU", data_dtype=torch.float16),
+    50: ConversionOption(
+        mode="FP16+COMPILE_CUDAGRAPHS", device_override="CUDA", data_dtype=torch.float16
+    ),
+    51: ConversionOption(
+        mode="FP16+COMPILE_INDUCTOR_DEFAULT", data_dtype=torch.float16
+    ),
+    52: ConversionOption(
+        mode="FP16+COMPILE_INDUCTOR_REDUCE_OVERHEAD", data_dtype=torch.float16
+    ),
+    53: ConversionOption(
+        mode="FP16+COMPILE_INDUCTOR_MAX_AUTOTUNE", data_dtype=torch.float16
+    ),
+    54: ConversionOption(
+        mode="FP16+COMPILE_INDUCTOR_EAGER_FALLBACK", data_dtype=torch.float16
+    ),
+    55: ConversionOption(
+        mode="FP16+COMPILE_ONNXRT", device_override="CUDA", data_dtype=torch.float16
+    ),
+    56: ConversionOption(
+        mode="FP16+COMPILE_OPENXLA", device_override="XLA_GPU", data_dtype=torch.float16
+    ),
     57: ConversionOption(mode="FP16+COMPILE_TVM", data_dtype=torch.float16),
     58: ConversionOption(mode="FP16+COMPILE_TENSORRT", data_dtype=torch.float16),
     59: ConversionOption(mode="FP16+COMPILE_OPENVINO", data_dtype=torch.float16),
-    60: ConversionOption(mode="FP16+EXPORT+COMPILE_CUDAGRAPHS", device_override="CUDA", data_dtype=torch.float16),
-    61: ConversionOption(mode="FP16+EXPORT+COMPILE_INDUCTOR_DEFAULT", data_dtype=torch.float16),
-    62: ConversionOption(mode="FP16+EXPORT+COMPILE_INDUCTOR_REDUCE_OVERHEAD", data_dtype=torch.float16),
-    63: ConversionOption(mode="FP16+EXPORT+COMPILE_INDUCTOR_MAX_AUTOTUNE", data_dtype=torch.float16),
-    64: ConversionOption(mode="FP16+EXPORT+COMPILE_INDUCTOR_DEFAULT_EAGER_FALLBACK", data_dtype=torch.float16),
-    65: ConversionOption(mode="FP16+EXPORT+COMPILE_ONNXRT", device_override="CUDA", data_dtype=torch.float16),
-    66: ConversionOption(mode="FP16+EXPORT+COMPILE_OPENXLA", device_override="XLA_GPU", data_dtype=torch.float16),
+    60: ConversionOption(
+        mode="FP16+EXPORT+COMPILE_CUDAGRAPHS",
+        device_override="CUDA",
+        data_dtype=torch.float16,
+    ),
+    61: ConversionOption(
+        mode="FP16+EXPORT+COMPILE_INDUCTOR_DEFAULT", data_dtype=torch.float16
+    ),
+    62: ConversionOption(
+        mode="FP16+EXPORT+COMPILE_INDUCTOR_REDUCE_OVERHEAD", data_dtype=torch.float16
+    ),
+    63: ConversionOption(
+        mode="FP16+EXPORT+COMPILE_INDUCTOR_MAX_AUTOTUNE", data_dtype=torch.float16
+    ),
+    64: ConversionOption(
+        mode="FP16+EXPORT+COMPILE_INDUCTOR_DEFAULT_EAGER_FALLBACK",
+        data_dtype=torch.float16,
+    ),
+    65: ConversionOption(
+        mode="FP16+EXPORT+COMPILE_ONNXRT",
+        device_override="CUDA",
+        data_dtype=torch.float16,
+    ),
+    66: ConversionOption(
+        mode="FP16+EXPORT+COMPILE_OPENXLA",
+        device_override="XLA_GPU",
+        data_dtype=torch.float16,
+    ),
     67: ConversionOption(mode="FP16+EXPORT+COMPILE_TVM", data_dtype=torch.float16),
     68: ConversionOption(mode="FP16+EXPORT+COMPILE_TENSORRT", data_dtype=torch.float16),
     69: ConversionOption(mode="FP16+EXPORT+COMPILE_OPENVINO", data_dtype=torch.float16),

--- a/src/alma/conversions/conversion_options.py
+++ b/src/alma/conversions/conversion_options.py
@@ -81,6 +81,28 @@ MODEL_CONVERSION_OPTIONS: dict[int, ConversionOption] = {
         mode="COMPILE_INDUCTOR_MAX_AUTOTUNE+TORCHAO_QUANT_I4_WEIGHT_ONLY"
     ),  # Requires bf16 suuport
     49: ConversionOption(mode="TORCHAO_QUANT_I4_WEIGHT_ONLY"),  # Requires bf16 support
+    50: ConversionOption(mode="FP16+COMPILE_CUDAGRAPHS", device_override="CUDA"),
+    51: ConversionOption(mode="FP16+COMPILE_INDUCTOR_DEFAULT"),
+    52: ConversionOption(mode="FP16+COMPILE_INDUCTOR_REDUCE_OVERHEAD"),
+    53: ConversionOption(mode="FP16+COMPILE_INDUCTOR_MAX_AUTOTUNE"),
+    54: ConversionOption(mode="FP16+COMPILE_INDUCTOR_EAGER_FALLBACK"),
+    55: ConversionOption(mode="FP16+COMPILE_ONNXRT", device_override="CUDA"),
+    56: ConversionOption(mode="FP16+COMPILE_OPENXLA", device_override="XLA_GPU"),
+    57: ConversionOption(mode="FP16+COMPILE_TVM"),
+    58: ConversionOption(mode="FP16+COMPILE_TENSORRT"),
+    59: ConversionOption(mode="FP16+COMPILE_OPENVINO"),
+    60: ConversionOption(mode="FP16+EXPORT+COMPILE_CUDAGRAPHS", device_override="CUDA"),
+    61: ConversionOption(mode="FP16+EXPORT+COMPILE_INDUCTOR_DEFAULT"),
+    62: ConversionOption(mode="FP16+EXPORT+COMPILE_INDUCTOR_REDUCE_OVERHEAD"),
+    63: ConversionOption(mode="FP16+EXPORT+COMPILE_INDUCTOR_MAX_AUTOTUNE"),
+    64: ConversionOption(mode="FP16+EXPORT+COMPILE_INDUCTOR_DEFAULT_EAGER_FALLBACK"),
+    65: ConversionOption(mode="FP16+EXPORT+COMPILE_ONNXRT", device_override="CUDA"),
+    66: ConversionOption(mode="FP16+EXPORT+COMPILE_OPENXLA", device_override="XLA_GPU"),
+    67: ConversionOption(mode="FP16+EXPORT+COMPILE_TVM"),
+    68: ConversionOption(mode="FP16+EXPORT+COMPILE_TENSORRT"),
+    69: ConversionOption(mode="FP16+EXPORT+COMPILE_OPENVINO"),
+    70: ConversionOption(mode="FP16+JIT_TRACE"),
+    71: ConversionOption(mode="FP16+TORCH_SCRIPT"),
 }
 
 

--- a/src/alma/conversions/options/fp16.py
+++ b/src/alma/conversions/options/fp16.py
@@ -36,3 +36,18 @@ def get_fp16_eager_forward_call(
         return model(data)
 
     return forward
+
+def get_fp16_model(
+    model: torch.nn.Module,
+) -> torch.nn.Module:
+    """
+    Cast the model to half precision and return the model.
+
+    Inputs:
+    - model (torch.nn.Module): The model to cast to half precision.
+
+    Returns:
+    - model (torch.nn.Module): the fp16 model.
+    """
+    model = model.half()
+    return model

--- a/src/alma/conversions/options/fp16.py
+++ b/src/alma/conversions/options/fp16.py
@@ -37,6 +37,7 @@ def get_fp16_eager_forward_call(
 
     return forward
 
+
 def get_fp16_model(
     model: torch.nn.Module,
 ) -> torch.nn.Module:

--- a/src/alma/conversions/select.py
+++ b/src/alma/conversions/select.py
@@ -27,7 +27,7 @@ from .options.export_compile import (
 from .options.export_eager import get_export_eager_forward_call
 from .options.export_quant import get_quant_exported_forward_call
 from .options.fake_quant import get_fake_quantized_model_forward_call
-from .options.fp16 import get_fp16_eager_forward_call
+from .options.fp16 import get_fp16_eager_forward_call, get_fp16_model
 from .options.jit_trace import get_jit_traced_model_forward_call
 from .options.onnx import get_onnx_dynamo_forward_call, get_onnx_forward_call
 from .options.optimum_quanto import (
@@ -114,8 +114,7 @@ def select_forward_call_function(
             check_tensort()
             forward = get_export_compiled_forward_call(model, data, backend="tensorrt")
 
-        case "COMPILE_OPENVINO":
-            check_tensort()
+        case "EXPORT+COMPILE_OPENVINO":
             forward = get_export_compiled_forward_call(model, data, backend="openvino")
 
         case "EXPORT+COMPILE_INDUCTOR_DEFAULT_EAGER_FALLBACK":
@@ -194,6 +193,9 @@ def select_forward_call_function(
         case "COMPILE_TENSORRT":
             check_tensort()
             forward = get_compiled_model_forward_call(model, data, backend="tensorrt")
+
+        case "COMPILE_OPENVINO":
+            forward = get_export_compiled_forward_call(model, data, backend="openvino")
 
         case "COMPILE_INDUCTOR_EAGER_FALLBACK":
             forward = get_compiled_forward_call_eager_fallback(
@@ -336,6 +338,122 @@ def select_forward_call_function(
 
         case "BF16+EAGER":
             forward = get_bfp16_eager_forward_call
+
+        case "FP16+COMPILE_CUDAGRAPHS":
+            model = get_fp16_model(model)
+            forward = get_compiled_model_forward_call(model, data, backend="cudagraphs")
+
+        case "FP16+COMPILE_INDUCTOR_DEFAULT":
+            model = get_fp16_model(model)
+            forward = get_compiled_model_forward_call(
+                model, data, backend="inductor-default"
+            )
+
+        case "FP16+COMPILE_INDUCTOR_REDUCE_OVERHEAD":
+            model = get_fp16_model(model)
+            forward = get_compiled_model_forward_call(
+                model, data, backend="inductor-reduce-overhead"
+            )
+
+        case "FP16+COMPILE_INDUCTOR_MAX_AUTOTUNE":
+            model = get_fp16_model(model)
+            forward = get_compiled_model_forward_call(
+                model, data, backend="inductor-max-autotune"
+            )
+
+        case "FP16+COMPILE_INDUCTOR_EAGER_FALLBACK":
+            model = get_fp16_model(model)
+            forward = get_compiled_forward_call_eager_fallback(
+                model, data, backend="inductor-default"
+            )
+
+        case "FP16+COMPILE_ONNXRT":
+            model = get_fp16_model(model)
+            check_onnxrt()
+            forward = get_compiled_model_forward_call(model, data, backend="onnxrt")
+
+        case "FP16+COMPILE_OPENXLA":
+            model = get_fp16_model(model)
+            check_openxla()
+            forward = get_compiled_model_forward_call(model, data, backend="openxla")
+
+        case "FP16+COMPILE_TVM":
+            model = get_fp16_model(model)
+            check_tvm()
+            forward = get_compiled_model_forward_call(model, data, backend="tvm")
+
+        case "FP16+COMPILE_TENSORRT":
+            model = get_fp16_model(model)
+            check_tensort()
+            forward = get_compiled_model_forward_call(model, data, backend="tensorrt")
+
+        case "FP16+COMPILE_OPENVINO":
+            model = get_fp16_model(model)
+            forward = get_compiled_model_forward_call(model, data, backend="openvino")
+
+        case "FP16+EXPORT+COMPILE_CUDAGRAPHS":
+            model = get_fp16_model(model)
+            forward = get_export_compiled_forward_call(
+                model, data, backend="cudagraphs"
+            )
+
+        case "FP16+EXPORT+COMPILE_INDUCTOR_DEFAULT":
+            model = get_fp16_model(model)
+            forward = get_export_compiled_forward_call(
+                model, data, backend="inductor-default"
+            )
+
+        case "FP16+EXPORT+COMPILE_INDUCTOR_REDUCE_OVERHEAD":
+            model = get_fp16_model(model)
+            forward = get_export_compiled_forward_call(
+                model, data, backend="inductor-reduce-overhead"
+            )
+
+        case "FP16+EXPORT+COMPILE_INDUCTOR_MAX_AUTOTUNE":
+            model = get_fp16_model(model)
+            forward = get_export_compiled_forward_call(
+                model, data, backend="inductor-max-autotune"
+            )
+
+        case "FP16+EXPORT+COMPILE_INDUCTOR_DEFAULT_EAGER_FALLBACK":
+            model = get_fp16_model(model)
+            forward = get_export_compiled_forward_call_eager_fallback(
+                model,
+                data,
+                backend="inductor-default",
+            )
+
+        case "FP16+EXPORT+COMPILE_ONNXRT":
+            model = get_fp16_model(model)
+            check_onnxrt()
+            forward = get_export_compiled_forward_call(model, data, backend="onnxrt")
+
+        case "FP16+EXPORT+COMPILE_OPENXLA":
+            model = get_fp16_model(model)
+            check_openxla()
+            forward = get_export_compiled_forward_call(model, data, backend="openxla")
+
+        case "FP16+EXPORT+COMPILE_TVM":
+            model = get_fp16_model(model)
+            check_tvm()
+            forward = get_export_compiled_forward_call(model, data, backend="tvm")
+
+        case "FP16+EXPORT+COMPILE_TENSORRT":
+            model = get_fp16_model(model)
+            check_tensort()
+            forward = get_export_compiled_forward_call(model, data, backend="tensorrt")
+
+        case "FP16+EXPORT+COMPILE_OPENVINO":
+            model = get_fp16_model(model)
+            forward = get_export_compiled_forward_call(model, data, backend="openvino")
+
+        case "FP16+JIT_TRACE":
+            model = get_fp16_model(model)
+            forward = get_jit_traced_model_forward_call(model, data)
+
+        case "FP16+TORCH_SCRIPT":
+            model = get_fp16_model(model)
+            forward = get_torch_scripted_model_forward_call(model)
 
         case _:
             error_msg = f"The option {conversion} is not supported"

--- a/src/alma/dataloader/create.py
+++ b/src/alma/dataloader/create.py
@@ -61,7 +61,6 @@ def create_single_tensor_dataloader(
         dtype=dtype,
     )
 
-
     return DataLoader(
         dataset,
         batch_size=batch_size,

--- a/src/alma/dataloader/create.py
+++ b/src/alma/dataloader/create.py
@@ -15,6 +15,7 @@ def create_single_tensor_dataloader(
     num_tensors: int = 100,
     random_type: str = "normal",
     random_params: Optional[dict] = None,
+    dtype: torch.dtype = torch.float32,
     **dataloader_kwargs,
 ) -> DataLoader:
     """
@@ -29,6 +30,7 @@ def create_single_tensor_dataloader(
         num_tensors: Number of random tensors to generate if no specific tensor provided
         random_type: Type of random tensors to generate ('normal', 'uniform', 'bernoulli')
         random_params: Parameters for random tensor generation
+        dtype: Data type of the tensor(s)
         **dataloader_kwargs: Additional arguments to pass to DataLoader
 
     Returns:
@@ -56,7 +58,9 @@ def create_single_tensor_dataloader(
         tensor=tensor,
         random_type=random_type,
         random_params=random_params,
+        dtype=dtype,
     )
+
 
     return DataLoader(
         dataset,

--- a/src/alma/dataloader/dataloader.py
+++ b/src/alma/dataloader/dataloader.py
@@ -19,6 +19,7 @@ class SingleTensorDataset(Dataset):
             - For 'normal': {'mean': float, 'std': float}
             - For 'uniform': {'low': float, 'high': float}
             - For 'bernoulli': {'p': float}
+    - dtype (torch.dtype, optional): Data type of the tensor(s).
     """
 
     def __init__(
@@ -28,6 +29,7 @@ class SingleTensorDataset(Dataset):
         tensor: Optional[torch.Tensor] = None,
         random_type: str = "normal",
         random_params: Optional[dict] = None,
+        dtype: torch.dtype = torch.float32,
     ):
         self.tensor_size = (
             tensor_size if isinstance(tensor_size, tuple) else (tensor_size,)
@@ -35,17 +37,21 @@ class SingleTensorDataset(Dataset):
 
         if tensor is not None:
             # Use the provided tensor
-            self.tensors = [tensor]
+            self.tensors = [tensor.to(dtype)]
             self.length = 1
         else:
             # Generate random tensors
             self.length = num_tensors
             self.tensors = self._generate_random_tensors(
-                random_type, random_params or {}, num_tensors
+                random_type, random_params or {}, num_tensors, dtype
             )
 
     def _generate_random_tensors(
-        self, random_type: str, params: dict, num_tensors: int
+        self,
+        random_type: str,
+        params: dict,
+        num_tensors: int,
+        dtype: torch.dtype = torch.float32,
     ) -> List[torch.Tensor]:
         """Generate a list of random tensors based on specified parameters."""
         tensors = []
@@ -71,6 +77,8 @@ class SingleTensorDataset(Dataset):
                     "Use 'normal', 'uniform', or 'bernoulli'."
                 )
 
+            # Convert the tensor to the specified dtype
+            tensor = tensor.to(dtype)
             tensors.append(tensor)
 
         return tensors


### PR DESCRIPTION
Added a large amount of float16 + compile options.

To get it working, needed to move the dataloader into the child process, which allows us to access the conversion option object so we can read the data type.

Some changes:
- Added data type to conversion option (needs updating for quantized options).
- Got rid of for loop in mem-efficient example, the logging bugged me.
- Moved dataloader initialisation into the child process, and at initialisation convert tensors to half dtype if desired.

Half precision options don't work nicely with torch.compile on Mac (MPS), but they do on CUDA.