### PR TITLE
Non-blocking data transfer

### DIFF
--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -463,6 +463,27 @@ config = BenchmarkConfig(
 )
 ```
 
+## Non-blocking host to device data trasnfer
+In many cases, speedups can be gained via setting the transfer of data from host (e.g. CPU) to 
+device (e.g. GPU) to be `non_blocking`:
+```python
+cuda_tensor = cpu_tensor.to("cuda", non_blocking=True)
+```
+
+[This blog](https://pytorch.org/tutorials/intermediate/pinmem_nonblock.html) discusses it 
+extensively, as well as the option of using pinned memory in the data loader. We follow the 
+PyTorch convention of having it default to `False`, but provide it as an option in the config, one 
+can set it to `True`.
+
+```python
+config = BenchmarkConfig(
+    n_samples=args.n_samples,
+    batch_size=args.batch_size,
+    device=device,
+    non_blocking=True,
+)
+```
+
 ## Logging and CI integration
 
 A lot of the imported modules have verbose logging, and so `alma` provides some logging functions

--- a/examples/mnist/benchmark_random_tensor.py
+++ b/examples/mnist/benchmark_random_tensor.py
@@ -38,6 +38,7 @@ def main() -> None:
         multiprocessing=True,  # If True, we test each method in its own isolated environment,
         # which helps keep methods from contaminating the global torch state
         fail_on_error=False,  # If False, we fail gracefully and keep testing other methods
+        non_blocking=False,  # If True, we don't block the main thread when transferring data from host to device
     )
 
     # Hard-code a list of options. These can be provided as a list of strings, or a list of ConversionOption objects

--- a/examples/mnist/benchmark_with_dataloader.py
+++ b/examples/mnist/benchmark_with_dataloader.py
@@ -54,6 +54,7 @@ def main() -> None:
         multiprocessing=True,  # If True, we test each method in its own isolated environment,
         # which helps keep methods from contaminating the global torch state
         fail_on_error=False,  # If False, we fail gracefully and keep testing other methods
+        non_blocking=False,  # If True, we don't block the main thread when transferring data from host to device
     )
 
     # Benchmark the model using the provided data loader.

--- a/examples/mnist/mem_efficient_benchmark_rand_tensor.py
+++ b/examples/mnist/mem_efficient_benchmark_rand_tensor.py
@@ -61,6 +61,7 @@ def main() -> None:
         multiprocessing=True,  # If True, we test each method in its own isolated environment,
         # which helps keep methods from contaminating the global torch state
         fail_on_error=False,  # If False, we fail gracefully and keep testing other methods
+        non_blocking=True,  # If True, we don't block the main thread when transferring data from host to device
         # Device options:
         allow_device_override=not args.no_device_override,  # Allow device override for device-specific conversions
         allow_cuda=not args.no_cuda,  # True allows CUDA as an override option

--- a/src/alma/benchmark/benchmark.py
+++ b/src/alma/benchmark/benchmark.py
@@ -118,8 +118,7 @@ def benchmark(
             if total_samples >= n_samples:
                 break
 
-            # data = data.to(device, non_blocking=True)
-            data = data.to(device)
+            data = data.to(device, non_blocking=config.non_blocking)
             batch_start_time = time.perf_counter()
             _ = forward_call(data)
             batch_end_time = time.perf_counter()

--- a/src/alma/benchmark/benchmark_config.py
+++ b/src/alma/benchmark/benchmark_config.py
@@ -19,6 +19,8 @@ class BenchmarkConfig(BaseModel):
         allow_cuda (bool): Allows CUDA usage if available. Defaults to True.
         allow_mps (bool): Allows MPS usage if available. Defaults to True.
         device (torch.device): Target device for benchmarking. Auto-selected if not provided.
+        non_blocking (bool): Whether to be blocking or not of the main thread when sending data
+        from host to device. Defaults to False.
     """
 
     n_samples: int = Field(
@@ -44,6 +46,9 @@ class BenchmarkConfig(BaseModel):
     )
     device: Optional[torch.device] = Field(
         default=None, description="Device for benchmarking."
+    )
+    non_blocking: bool = Field(
+        default=False, description="Blocking or not when transferring data from host to device"
     )
 
     class Config:

--- a/src/alma/benchmark/benchmark_config.py
+++ b/src/alma/benchmark/benchmark_config.py
@@ -48,7 +48,8 @@ class BenchmarkConfig(BaseModel):
         default=None, description="Device for benchmarking."
     )
     non_blocking: bool = Field(
-        default=False, description="Blocking or not when transferring data from host to device"
+        default=False,
+        description="Blocking or not when transferring data from host to device",
     )
 
     class Config:


### PR DESCRIPTION
Sets non-blocking as the default in the benchmarking loop.
Give the option to set the `pin_memory` argument in the initialized DataLoader, and the `num_workers`, both controlled via the `BenchmarkConfig`. Higher numbers of workers can be good for big tensors, but can be counter-productive for smaller tensors because of the multi-processing overhead.


Closes #113 