### PR TITLE
Make benchmarking loop measurefull end-to-end throughout of model

### DIFF
--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -1,8 +1,15 @@
 # MNIST example
 
 This example of `alma` demonstrates how to train a simple model on the MNIST dataset and benchmark
-the model speed for different conversions using the `benchmark_model` API. Everything, from not using
-a dataloader, to error handling, CLI integration, multiprocessing, logging and debugging, is covered.
+the model speed for different conversions using the `benchmark_model` API. The example covers:
+
+- Using custom dataloaders or auto-generated data
+- Error handling and graceful failure modes
+- CLI integration and argument parsing
+- Multiprocessing for isolated benchmarking environments
+- Comprehensive logging and debugging support
+- Non-blocking data transfer optimization
+- Device fallback handling
 
 It also contains a script to download the MNIST dataset, and extensive example code on how to quantize
 a model using PTQ and QAT.

--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -76,7 +76,13 @@ device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 model = ...
 
 # Load the data
-data_loader = ...
+data_loader = YourDataLoader(
+    dataset,
+    batch_size=100,
+    shuffle=False,
+    num_workers=8, # Along with pinned memory, number of workers can optimize data load times
+    pin_memory=True,
+)
 
 # Set the configuration
 config = BenchmarkConfig(
@@ -478,9 +484,9 @@ cuda_tensor = cpu_tensor.to("cuda", non_blocking=True)
 ```
 
 [This blog](https://pytorch.org/tutorials/intermediate/pinmem_nonblock.html) discusses it 
-extensively, as well as the option of using pinned memory in the data loader. We follow the 
-PyTorch convention of having it default to `False`, but provide it as an option in the config, one 
-can set it to `True`.
+extensively, as well as the option of using pinned memory and multiple workers in the data loader. 
+We follow the PyTorch convention of having it default to `False`, but provide it as an option in 
+the config, one can set it to `True`.
 
 ```python
 config = BenchmarkConfig(

--- a/examples/mnist/benchmark_random_tensor.py
+++ b/examples/mnist/benchmark_random_tensor.py
@@ -49,6 +49,7 @@ def main() -> None:
         "COMPILE_INDUCTOR_DEFAULT",
         "COMPILE_OPENXLA",
         "COMPILE_INDUCTOR_MAX_AUTOTUNE",
+        "COMPILE_CUDAGRAPHS",
     ]
     # conversions = [ConversionOption["EAGER"], ConversionOption["JIT_TRACE"], ConversionOption["TORCH_SCRIPT"], ConversionOption["COMPILE_INDUCTOR_DEFAULT"]]
 

--- a/examples/mnist/benchmark_with_dataloader.py
+++ b/examples/mnist/benchmark_with_dataloader.py
@@ -37,6 +37,10 @@ def main() -> None:
         dataset,
         batch_size=args.batch_size,
         shuffle=False,
+        # Multiple workers and pinned memory, along with non_blocking in the config, can speed up
+        # data loading and throughput.
+        # See this blog (https://pytorch.org/tutorials/intermediate/pinmem_nonblock.html)
+        # for details
         num_workers=8,
         pin_memory=True,
     )
@@ -58,7 +62,7 @@ def main() -> None:
         multiprocessing=True,  # If True, we test each method in its own isolated environment,
         # which helps keep methods from contaminating the global torch state
         fail_on_error=False,  # If False, we fail gracefully and keep testing other methods
-        non_blocking=False,  # If True, we don't block the main thread when transferring data from host to device
+        non_blocking=True,  # If True, we don't block the main thread when transferring data from host to device
     )
 
     # Benchmark the model using the provided data loader.

--- a/examples/mnist/benchmark_with_dataloader.py
+++ b/examples/mnist/benchmark_with_dataloader.py
@@ -13,7 +13,6 @@ from alma.arguments.benchmark_args import parse_benchmark_args
 from alma.benchmark import BenchmarkConfig
 from alma.benchmark.log import display_all_results
 from alma.benchmark_model import benchmark_model
-from alma.utils.load_model import load_model
 from alma.utils.setup_logging import setup_logging
 
 # One needs to set their quantization backend engine to what is appropriate for their system.
@@ -34,15 +33,20 @@ def main() -> None:
     dataset = BenchmarkCustomImageDataset(
         img_dir=args.data_dir, transform=InferenceTransform
     )
-    data_loader = CircularDataLoader(dataset, batch_size=args.batch_size, shuffle=False)
+    data_loader = CircularDataLoader(
+        dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=8,
+        pin_memory=True,
+    )
 
     # Set the device one wants to benchmark on
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
 
     # Load model
-    assert args.model_path is not None, "Please provide a model path"
     load_start_time = time.perf_counter()
-    model = load_model(args.model_path, device, logger=logging, modelArchitecture=Net)
+    model = Net()
     load_end_time = time.perf_counter()
     logging.info(f"Model loading time: {load_end_time - load_start_time:.4f} seconds")
 

--- a/examples/mnist/mem_efficient_benchmark_rand_tensor.py
+++ b/examples/mnist/mem_efficient_benchmark_rand_tensor.py
@@ -61,7 +61,7 @@ def main() -> None:
         multiprocessing=True,  # If True, we test each method in its own isolated environment,
         # which helps keep methods from contaminating the global torch state
         fail_on_error=False,  # If False, we fail gracefully and keep testing other methods
-        non_blocking=True,  # If True, we don't block the main thread when transferring data from host to device
+        non_blocking=False,  # If True, we don't block the main thread when transferring data from host to device
         # Device options:
         allow_device_override=not args.no_device_override,  # Allow device override for device-specific conversions
         allow_cuda=not args.no_cuda,  # True allows CUDA as an override option

--- a/src/alma/benchmark/benchmark.py
+++ b/src/alma/benchmark/benchmark.py
@@ -120,17 +120,19 @@ def benchmark(
 
     # Calculate number of full batches needed
     n_batches = (n_samples + config.batch_size - 1) // config.batch_size
-    
+
     # Benchmarking loop - only process full batches
     with torch.no_grad():
-        for i, (data, _) in enumerate(tqdm(
-            data_loader,
-            desc=f"Benchmarking {conversion.mode} on {device}",
-            total=n_batches,
-        )):
+        for i, (data, _) in enumerate(
+            tqdm(
+                data_loader,
+                desc=f"Benchmarking {conversion.mode} on {device}",
+                total=n_batches,
+            )
+        ):
             # Transfer data to device
             data = data.to(device, non_blocking=config.non_blocking)
-            
+
             # Run forward pass without per-batch timing
             _ = forward_call(data)
             total_samples += data.size(0)

--- a/src/alma/benchmark/benchmark.py
+++ b/src/alma/benchmark/benchmark.py
@@ -135,6 +135,9 @@ def benchmark(
             _ = forward_call(data)
             total_samples += data.size(0)
 
+            if total_samples > n_samples:
+                break
+
     # End timing and synchronize if needed
     if device.type == "cuda":
         end_event.record()

--- a/src/alma/benchmark/log.py
+++ b/src/alma/benchmark/log.py
@@ -62,9 +62,9 @@ def log_results(
     None
     """
     display_function(f"Device: {results['device']}")
-    display_function(f"Total elapsed time: {results['total_elapsed_time']:.6f} seconds")
+    display_function(f"Total elapsed time: {results['total_elapsed_time']:.3f} seconds")
     display_function(
-        f"Total inference time (model only): {results['total_inf_time']:.6f} seconds"
+        f"Mean batch time: {results['mean_batch_time']:.3f} seconds ± {results['batch_time_std']:.3f}"
     )
     display_function(
         f"Total samples: {results['total_samples']} - Batch size: {results['batch_size']}"

--- a/src/alma/benchmark/log.py
+++ b/src/alma/benchmark/log.py
@@ -64,9 +64,6 @@ def log_results(
     display_function(f"Device: {results['device']}")
     display_function(f"Total elapsed time: {results['total_elapsed_time']:.3f} seconds")
     display_function(
-        f"Mean batch time: {results['mean_batch_time']:.3f} seconds ± {results['batch_time_std']:.3f}"
-    )
-    display_function(
         f"Total samples: {results['total_samples']} - Batch size: {results['batch_size']}"
     )
     display_function(f"Data dtype: {results['data_dtype']}")

--- a/src/alma/benchmark_model.py
+++ b/src/alma/benchmark_model.py
@@ -25,7 +25,7 @@ def benchmark_model(
     conversions: Optional[Union[List[ConversionOption], List[str]]] = None,
     data: Optional[torch.Tensor] = None,
     data_loader: Optional[DataLoader] = None,
-) -> Dict[str, Dict[str, Any]]:
+) -> Dict[str, Dict[str, Union[str, float, int, Exception]]]:
     """
     Benchmark the model on different conversion methods. If provided, the dataloader will be used.
     Else, a random dataloader will be created, in which case the `data` tensor must be provided
@@ -56,11 +56,15 @@ def benchmark_model(
         data_loader (Optional[DataLoader]): DataLoader for data samples. If provided, it takes precedence.
 
     Returns:
-    - all_results (Dict[str, Dict[str, Any]]): The results of the benchmarking for each conversion method.
+        Dict[str, Dict[str, Union[str, float, int, Exception]]]: The results of the benchmarking for each conversion method.
+            Each key is a conversion method name, and the value is a dictionary containing:
+            - For successful runs: elapsed time, total time, number of samples, and throughput
+            - For failed runs: error message and traceback (when fail_on_error=False)
         The key is the conversion method, and the value is a tuple containing the total elapsed
         time, the total time taken, the total number of samples, and the throughput of the model.
         If the conversion method failed and we fail gracefully, the value will be a dictionary
-        containing the error and traceback.            If a method fails, its value contains the error message and traceback.
+        containing the error and traceback.
+        If a method fails, its value contains the error message and traceback.
     """
     # If the config is a dictionary, we convert it to a BenchmarkConfig object
     if isinstance(config, dict):
@@ -149,8 +153,8 @@ if __name__ == "__main__":
     sample_data = torch.randn(32, 10)
 
     conversions = [
-        MODEL_CONVERSION_OPTIONS[0],  # EAGER mode
-        MODEL_CONVERSION_OPTIONS[2],  # ONNX_CPU mode
+        MODEL_CONVERSION_OPTIONS["EAGER"],  # EAGER mode
+        MODEL_CONVERSION_OPTIONS["EAGER+EXPORT"],  # EAGER+EXPORT
     ]
 
     # Run benchmark


### PR DESCRIPTION

## Minor example updates
Updated some examples, e.g. added multiple workers and pinned memory details to data loader example.

## More accurate throughput measurements

The old code only accumulates the time spent in forward passes, which is artificially fast.

The new code includes:
  - Data transfer time (`.to(device)`)
  - CUDA queue scheduling overhead
  - Any inter-batch synchronization/overhead
  - DataLoader iteration overhead


**Previous timings example:**
```
COMPILE_INDUCTOR_MAX_AUTOTUNE results:
Device: cuda
Total elapsed time: 0.012508 seconds
Total inference time (model only): 0.003409 seconds
Total samples: 2048 - Batch size: 64
Data dtype: torch.float32
Throughput: 600846.05 samples/second


COMPILE_OPENXLA results:
Device: xla:0
Total elapsed time: 0.013253 seconds
Total inference time (model only): 0.003098 seconds
Total samples: 2048 - Batch size: 64
Data dtype: torch.float32
Throughput: 661091.90 samples/second

```

**New timings:**
``` 
COMPILE_INDUCTOR_MAX_AUTOTUNE results:
Device: cuda
Total elapsed time: 0.012 seconds
Total samples: 2048 - Batch size: 64
Data dtype: torch.float32
Throughput: 174216.03 samples/second


COMPILE_OPENXLA results:
Device: xla:0
Total elapsed time: 0.011 seconds
Total samples: 2048 - Batch size: 64
Data dtype: torch.float32
Throughput: 179965.56 samples/second
```