### PR TITLE
Lazyload for memory efficiency

### DIFF
--- a/examples/linear/README.md
+++ b/examples/linear/README.md
@@ -51,10 +51,10 @@ display_all_results(results)
 ```
 
 ### Full working example:
-A full working example can be found in `examples/mnist/benchmark_random_tensor.py` where a random model is used.
+A full working example can be found in `examples/linear/benchmark_random_tensor.py` where a random model is used.
 E.g.
 ```bash
-cd examples/mnist
+cd examples/linear
 python benchmark_random_tensor.py  --conversions EAGER,EXPORT+EAGER --batch-size 10
 --n-samples 5000 
 ```

--- a/examples/linear/benchmark_random_tensor.py
+++ b/examples/linear/benchmark_random_tensor.py
@@ -8,6 +8,7 @@ from alma.benchmark import BenchmarkConfig
 from alma.benchmark.log import display_all_results
 from alma.benchmark_model import benchmark_model
 from alma.utils.setup_logging import setup_logging
+from alma.utils.multiprocessing.lazyload import lazyload
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -26,10 +27,14 @@ def main() -> None:
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
 
     # Create a random model
+    # NOTE: We use the lazyload decorator to ensure this is alo loaded once it is used, which can have better
+    # memory usage under multiprocessing scenarios
+    @lazyload
     model = torch.nn.Sequential(
         torch.nn.Linear(3, 3),
         torch.nn.ReLU(),
     )
+    import ipdb, pprint; ipdb.set_trace();
 
     # Create a random tensor
     data = torch.rand(1, 512, 3)

--- a/examples/linear/benchmark_random_tensor.py
+++ b/examples/linear/benchmark_random_tensor.py
@@ -7,8 +7,8 @@ from alma.arguments.benchmark_args import parse_benchmark_args
 from alma.benchmark import BenchmarkConfig
 from alma.benchmark.log import display_all_results
 from alma.benchmark_model import benchmark_model
-from alma.utils.setup_logging import setup_logging
 from alma.utils.multiprocessing.lazyload import lazyload
+from alma.utils.setup_logging import setup_logging
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -27,14 +27,18 @@ def main() -> None:
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
 
     # Create a random model
-    # NOTE: We use the lazyload decorator to ensure this is alo loaded once it is used, which can have better
-    # memory usage under multiprocessing scenarios
-    @lazyload
-    model = torch.nn.Sequential(
-        torch.nn.Linear(3, 3),
-        torch.nn.ReLU(),
+    # NOTE: We use the lazyload wrapper to ensure this is only loaded once we call it within the `benchmark` function.
+    # This is because under multiprocessing setups, where we use multiprocessing to ensure that each export/compilation
+    # option occurs in a standalone environment to prevent global torch state contamination, there is a risk
+    # that a model could be loaded here at initialisation, and again inside the child process. A lazyload ensures
+    # that we only load it within the child processes, which uses half the memory for model storage compared to also
+    # loading it here in the parent process.
+    model = lazyload(
+        lambda: torch.nn.Sequential(
+            torch.nn.Linear(3, 3),
+            torch.nn.ReLU(),
+        )
     )
-    import ipdb, pprint; ipdb.set_trace();
 
     # Create a random tensor
     data = torch.rand(1, 512, 3)

--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -395,16 +395,20 @@ from the parent process to the child process. This doubles the required model me
 a problem for large models. To avoid this, one can, insead of feeding in a model
 directly to `benchmark_model`, feed in a function that returns the model. This way, the model is 
 only initialized once the child process starts for each conversion method, meaning we only have 
-one copy of the model at a time in device memory.
+one copy of the model at a time in device memory. 
 
+To make this easy, we provide a `lazyload` decorator one can use at model initialisation to have
+it only load once it is called.
 E.g.
 
 ```python
+from alma.utils.multiprocessing.lazyload import lazyload
 ...
 
-# This callable function returns the model, only once when we call it inside the child process
-def get_model():
-    return Net()
+# The model will only be properly initialised once called inside the benchmark process, meaning
+# multiple copies of the model will not be made (here and inside the child process).
+@lazyload
+model = Net()
 
 config = BenchmarkConfig(
     n_samples=args.n_samples,

--- a/examples/mnist/README.md
+++ b/examples/mnist/README.md
@@ -397,7 +397,7 @@ directly to `benchmark_model`, feed in a function that returns the model. This w
 only initialized once the child process starts for each conversion method, meaning we only have 
 one copy of the model at a time in device memory. 
 
-To make this easy, we provide a `lazyload` decorator one can use at model initialisation to have
+To make this easy, we provide a `lazyload` function one can use at model initialisation to have
 it only load once it is called.
 E.g.
 
@@ -407,8 +407,7 @@ from alma.utils.multiprocessing.lazyload import lazyload
 
 # The model will only be properly initialised once called inside the benchmark process, meaning
 # multiple copies of the model will not be made (here and inside the child process).
-@lazyload
-model = Net()
+model = lazyload(Net)
 
 config = BenchmarkConfig(
     n_samples=args.n_samples,

--- a/examples/mnist/benchmark_random_tensor.py
+++ b/examples/mnist/benchmark_random_tensor.py
@@ -8,6 +8,7 @@ from utils.file_utils import save_dict_to_json
 from alma.benchmark import BenchmarkConfig
 from alma.benchmark.log import display_all_results
 from alma.benchmark_model import benchmark_model
+from alma.utils.multiprocessing.lazyload import lazyload
 from alma.utils.setup_logging import setup_logging
 
 # One needs to set their quantization backend engine to what is appropriate for their system.
@@ -28,6 +29,9 @@ def main() -> None:
     data = torch.rand(1, 3, 28, 28)
 
     # Load model (random weights)
+    # NOTE: We use the lazyload decorator to ensure this is alo loaded once it is used, which can have better
+    # memory usage under multiprocessing scenarios
+    @lazyload
     model = Net()
 
     # Configuration for the benchmarking

--- a/examples/mnist/benchmark_random_tensor.py
+++ b/examples/mnist/benchmark_random_tensor.py
@@ -29,9 +29,8 @@ def main() -> None:
     data = torch.rand(1, 3, 28, 28)
 
     # Load model (random weights)
-    # NOTE: We use the lazyload decorator to ensure this is alo loaded once it is used, which can have better
-    # memory usage under multiprocessing scenarios
-    @lazyload
+    # NOTE: Here we don't use the lazyload decorator on purpose, which will cause the model to be initialised immediately.
+    # Since we are using Multiprocessing, this will log a warning about inefficient memory usage.
     model = Net()
 
     # Configuration for the benchmarking

--- a/examples/mnist/benchmark_with_dataloader.py
+++ b/examples/mnist/benchmark_with_dataloader.py
@@ -13,8 +13,8 @@ from alma.arguments.benchmark_args import parse_benchmark_args
 from alma.benchmark import BenchmarkConfig
 from alma.benchmark.log import display_all_results
 from alma.benchmark_model import benchmark_model
-from alma.utils.setup_logging import setup_logging
 from alma.utils.multiprocessing.lazyload import lazyload
+from alma.utils.setup_logging import setup_logging
 
 # One needs to set their quantization backend engine to what is appropriate for their system.
 # torch.backends.quantized.engine = 'x86'
@@ -51,8 +51,8 @@ def main() -> None:
 
     # Load model
     load_start_time = time.perf_counter()
-    # NOTE: Here we don't use the lazyload decorator on purpose, which will cause the model to be initialised immediately
-    @lazyload
+    # NOTE: Here we don't use the lazyload decorator on purpose, which will cause the model to be initialised immediately.
+    # Since we are using Multiprocessing, this will log a warning about inefficient memory usage.
     model = Net()
     load_end_time = time.perf_counter()
     logging.info(f"Model loading time: {load_end_time - load_start_time:.4f} seconds")

--- a/examples/mnist/benchmark_with_dataloader.py
+++ b/examples/mnist/benchmark_with_dataloader.py
@@ -14,6 +14,7 @@ from alma.benchmark import BenchmarkConfig
 from alma.benchmark.log import display_all_results
 from alma.benchmark_model import benchmark_model
 from alma.utils.setup_logging import setup_logging
+from alma.utils.multiprocessing.lazyload import lazyload
 
 # One needs to set their quantization backend engine to what is appropriate for their system.
 # torch.backends.quantized.engine = 'x86'
@@ -50,6 +51,8 @@ def main() -> None:
 
     # Load model
     load_start_time = time.perf_counter()
+    # NOTE: Here we don't use the lazyload decorator on purpose, which will cause the model to be initialised immediately
+    @lazyload
     model = Net()
     load_end_time = time.perf_counter()
     logging.info(f"Model loading time: {load_end_time - load_start_time:.4f} seconds")

--- a/examples/mnist/mem_efficient_benchmark_rand_tensor.py
+++ b/examples/mnist/mem_efficient_benchmark_rand_tensor.py
@@ -40,8 +40,9 @@ def main() -> None:
     # process. This is especially important if the model is large and two instances would not fit
     # on device.
     # We accomplish this via the lazyload function, which initializes a Lazyload instance, which will
-    # cause the model to ony be loaded when called, not at initialisation.
-    model = lazyload(Net)
+    # cause the model to ony be loaded when called, not at initialisation. The `lambda` is key to this,
+    # otherwise the model will be initialised immediately.
+    model = lazyload(lambda: Net())
 
     # Configuration for the benchmarking. Here we show of all of the options, including for device.
     # With `allow_device_override` we allow a device-specific conversion method to automtically assign

--- a/examples/mnist/mem_efficient_benchmark_rand_tensor.py
+++ b/examples/mnist/mem_efficient_benchmark_rand_tensor.py
@@ -9,33 +9,12 @@ from alma.benchmark import BenchmarkConfig
 from alma.benchmark.log import display_all_results
 from alma.benchmark_model import benchmark_model
 from alma.utils.device import setup_device
-from alma.utils.setup_logging import setup_logging
 from alma.utils.multiprocessing.lazyload import lazyload
+from alma.utils.setup_logging import setup_logging
 
 # One needs to set their quantization backend engine to what is appropriate for their system.
 # torch.backends.quantized.engine = 'x86'
 torch.backends.quantized.engine = "qnnpack"
-
-
-# It is a lot more memory efficienct, if multi-processing is enabled, to create the model in a
-# callable function, which can be called later to create the model.
-# This allows us to initialise the model in each child process, rather than the parent
-# process. This is because the model is not pickled and sent to the child process (which would
-# require the program to sotre the model in memory twice), but rather created in the child
-# process. This is especially important if the model is large and two instances would not fit
-# on device.
-def model_init() -> torch.nn.Module:
-    """
-    A callable that returns the model to be benchmarked. This allows us to initialise the model
-    at a later date, which is useful when using multiprocessing (in turn used to isolate each method
-    in its own process, keeping them from contaminating the global torch state). By initialising
-    the model inside the child process, we avoid having two instances of the model in memory at
-    once.
-
-    NOTE: THIS HAS TO BE DEFINED AT THE MODULE LEVEL, NOT NESTED INSIDE ANY FUNCTION. This is so
-    that it is pickle-able, necessary for it to be passed to multi-processing.
-    """
-    return Net()
 
 
 def main() -> None:
@@ -53,17 +32,16 @@ def main() -> None:
         None, allow_cuda=(not args.no_cuda), allow_mps=(not args.no_mps)
     )
 
-    # It is a lot more memory efficienct, if multi-processing is enabled, to create the model in a
+    # It is a lot more memory efficient, if multi-processing is enabled, to create the model in a
     # callable function, which can be called later to create the model.
     # This allows us to initialise the model in each child process, rather than the parent
     # process. This is because the model is not pickled and sent to the child process (which would
     # require the program to sotre the model in memory twice), but rather created in the child
     # process. This is especially important if the model is large and two instances would not fit
     # on device.
-    # We accomplish this via the lazyload decorator, which will cause the model to ony be loaded
-    # when called, not at initialisation
-    @lazyload
-    model = Net()
+    # We accomplish this via the lazyload function, which initializes a Lazyload instance, which will
+    # cause the model to ony be loaded when called, not at initialisation.
+    model = lazyload(Net)
 
     # Configuration for the benchmarking. Here we show of all of the options, including for device.
     # With `allow_device_override` we allow a device-specific conversion method to automtically assign
@@ -94,7 +72,7 @@ def main() -> None:
         "Benchmarking model using random data, passing in a callable to initialise the model"
     )
     results: Dict[str, Dict[str, Any]] = benchmark_model(
-        model_init,
+        model,
         config,
         conversions,
         data=data.squeeze(),

--- a/src/alma/benchmark_model.py
+++ b/src/alma/benchmark_model.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import torch
 from torch.utils.data import DataLoader
@@ -20,7 +20,7 @@ logger.addHandler(logging.NullHandler())
 
 
 def benchmark_model(
-    model: Union[torch.nn.Module, Callable],
+    model: Any,
     config: Union[BenchmarkConfig, Dict[str, Any]],
     conversions: Optional[Union[List[ConversionOption], List[str]]] = None,
     data: Optional[torch.Tensor] = None,
@@ -44,7 +44,7 @@ def benchmark_model(
         the error message and traceback in the returned struct.
 
     Args:
-        model (Union[torch.nn.Module, Callable]): The model to benchmark. If a callable is provided,
+        model (Any): The model to benchmark. If a LazyLoader instance is provided,
             it should return the model instance. This helps when using multiprocessing, as the model
             can be instantiated inside isolated child processes.
         config (Union[BenchmarkConfig, Dict[str, Any]]): A validated Pydantic configuration for benchmarking.

--- a/src/alma/utils/checks/all.py
+++ b/src/alma/utils/checks/all.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Union
+from typing import Any, List, Union
 
 import torch
 from torch.utils.data import DataLoader
@@ -12,7 +12,7 @@ from .model import check_model
 
 
 def check_inputs(
-    model: Union[torch.nn.Module, Callable],
+    model: Any,
     config: BenchmarkConfig,
     conversions: Union[List[str], None],
     data: Union[torch.Tensor, None],

--- a/src/alma/utils/checks/model.py
+++ b/src/alma/utils/checks/model.py
@@ -11,18 +11,20 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def check_model(model: Union[torch.nn.Module, Callable], config: dict) -> None:
+def check_model(model: Callable, config: dict) -> None:
     """
     Checks if the model (or init function) is valid, and logs a warning if a memory inefficient
     process is being used.
 
     Inputs:
-    - model (Union[torch.nn.Module, Callable]): The model to benchmark, or a callable function to get the model.
+    - model (Callable): The model to benchmark, or a callable function to get the model.
     - config (dict): The configuration for the benchmarking.
 
     Outputs:
     None
     """
+    assert callable(model), "The model should always be a callable"
+
     # If we are doing multiprocessing and the model is being LazyLoaded, that's perfect
     if isinstance(model, LazyLoader) and config.multiprocessing:
         # Unless it's already been loaded

--- a/src/alma/utils/multiprocessing/__init__.py
+++ b/src/alma/utils/multiprocessing/__init__.py
@@ -1,2 +1,3 @@
 from .error_handling import benchmark_error_handler
 from .multiprocessing import benchmark_process_wrapper
+from .lazyload import init_lazy_model, lazyload

--- a/src/alma/utils/multiprocessing/__init__.py
+++ b/src/alma/utils/multiprocessing/__init__.py
@@ -1,3 +1,3 @@
 from .error_handling import benchmark_error_handler
+from .lazyload import LazyLoader, init_lazy_model, lazyload
 from .multiprocessing import benchmark_process_wrapper
-from .lazyload import init_lazy_model, lazyload

--- a/src/alma/utils/multiprocessing/lazyload.py
+++ b/src/alma/utils/multiprocessing/lazyload.py
@@ -1,23 +1,18 @@
-import functools
-from typing import Any, Callable, TypeVar, Type
-
-T = TypeVar("T")
+from typing import Any, Callable
 
 
 class LazyLoader:
     """A lazy loader that defers object creation until accessed."""
 
-    def __init__(self, cls: Type[T], *args, **kwargs):
-        self._cls = cls
-        self._args = args
-        self._kwargs = kwargs
+    def __init__(self, factory: Callable[[], Any]):
+        self._factory = factory
         self._instance = None
         self._loaded = False
 
-    def load(self) -> T:
+    def load(self) -> Any:
         """Load the actual object and return it."""
         if not self._loaded:
-            self._instance = self._cls(*self._args, **self._kwargs)
+            self._instance = self._factory()
             self._loaded = True
         return self._instance
 
@@ -31,7 +26,7 @@ class LazyLoader:
         self._loaded = False
 
     def __call__(self, *args, **kwargs):
-        """Allow the lazy loader to be called like the original class."""
+        """Allow the lazy loader to be called like the original object."""
         return self.load()(*args, **kwargs)
 
     def __getattr__(self, name):
@@ -39,146 +34,29 @@ class LazyLoader:
         return getattr(self.load(), name)
 
 
-def init_lazy_model(obj_or_cls):
+def lazyload(factory: Callable[[], Any]) -> LazyLoader:
     """
-    Get the original class from a lazy-loaded object or class.
-    
-    Args:
-        obj_or_cls: LazyLoader instance or lazyloaded class
-        
-    Returns:
-        The original class, or the input if it's not lazy-loaded
-    """
-    if isinstance(obj_or_cls, LazyLoader):
-        return obj_or_cls._cls
-    elif hasattr(obj_or_cls, '_original_class'):
-        return obj_or_cls._original_class
-    else:
-        return obj_or_cls
-
-
-def lazyload(cls: Type[T]) -> Type[T]:
-    """
-    Decorator that makes class instantiation lazy.
+    Create a lazy loader from a factory function.
 
     Usage:
-        @lazyload
-        model = Model(param1, param2)
-
-        # model is now a LazyLoader, actual Model() is not created yet
-        # When you need the actual model:
-        actual_model = model.load()
-
-        # Or access attributes directly (auto-loads):
-        result = model.some_method()  # This will load Model() first
+        model = lazy(lambda: torch.nn.Sequential(...))
+        # or
+        model = lazy(lambda: MyModel(param1, param2))
     """
-
-    class LazyWrapper:
-        def __new__(cls, *args, **kwargs):
-            return LazyLoader(cls._original_class, *args, **kwargs)
-
-    LazyWrapper._original_class = cls
-    LazyWrapper.__name__ = cls.__name__
-    LazyWrapper.__qualname__ = cls.__qualname__
-
-    return LazyWrapper
+    return LazyLoader(factory)
 
 
-# Alternative implementation using a metaclass approach
-class LazyMeta(type):
-    """Metaclass that creates lazy-loading classes."""
+def init_lazy_model(obj_or_cls: Any) -> Any:
+    """
+    Load the model, if it is LazyLoader instance and has not yet been loaded.
 
-    def __call__(cls, *args, **kwargs):
-        if hasattr(cls, "_lazy_enabled"):
-            return LazyLoader(cls._original_class, *args, **kwargs)
-        else:
-            return super().__call__(*args, **kwargs)
+    Args:
+        obj_or_cls (Any): Instance that may be a LazyLoader instance or not.
 
-
-def lazyload_meta(cls: Type[T]) -> Type[T]:
-    """Alternative implementation using metaclass."""
-
-    class LazyClass(cls, metaclass=LazyMeta):
-        _lazy_enabled = True
-        _original_class = cls
-
-    LazyClass.__name__ = cls.__name__
-    LazyClass.__qualname__ = cls.__qualname__
-
-    return LazyClass
-
-
-# Example usage
-if __name__ == "__main__":
-    import time
-
-    # Example model class
-    class Model:
-        def __init__(self, name="default", size=100):
-            print(f"Loading model '{name}' with size {size}... (expensive operation)")
-            time.sleep(0.5)  # Simulate expensive loading
-            self.name = name
-            self.size = size
-            self.data = list(range(size))
-
-        def predict(self, x):
-            return f"Model {self.name} predicts: {x * 2}"
-
-        def __str__(self):
-            return f"Model(name={self.name}, size={self.size})"
-
-    print("=== Without decorator (normal behavior) ===")
-    normal_model = Model("normal", 50)
-    print(f"Normal model: {normal_model}")
-
-    print("\n=== With @lazyload decorator ===")
-
-    @lazyload
-    class Model:
-        def __init__(self, name="default", size=100):
-            print(f"Loading model '{name}' with size {size}... (expensive operation)")
-            time.sleep(0.5)  # Simulate expensive loading
-            self.name = name
-            self.size = size
-            self.data = list(range(size))
-
-        def predict(self, x):
-            return f"Model {self.name} predicts: {x * 2}"
-
-        def __str__(self):
-            return f"Model(name={self.name}, size={self.size})"
-
-    # This looks exactly like normal instantiation, but no loading happens yet
-    model = Model("lazy", 200)
-
-    print(f"Model created (type: {type(model)})")
-    print(f"Is loaded: {model.is_loaded()}")
-
-    print("Accessing model attribute (triggers loading)...")
-    result = model.predict(5)
-    print(f"Prediction result: {result}")
-    print(f"Is loaded: {model.is_loaded()}")
-
-    print("\nManual loading example:")
-
-    @lazyload
-    class AnotherModel:
-        def __init__(self, value):
-            print(f"Actually creating AnotherModel with value {value}")
-            self.value = value
-
-    lazy_model = AnotherModel(42)
-    print(f"Lazy model created, loaded: {lazy_model.is_loaded()}")
-
-    actual_model = lazy_model.load()
-    print(f"Actual model: {actual_model.value}")
-    print(f"Now loaded: {lazy_model.is_loaded()}")
-
-    # For multiprocessing, you can pass the LazyLoader object
-    def worker_function(lazy_obj):
-        # In subprocess, load the actual object
-        obj = lazy_obj.load()
-        return f"Worker processed: {obj}"
-
-    result = worker_function(lazy_model)
-    print(f"Worker result: {result}")
+    Returns:
+        (Any): The loaded model.
+    """
+    if isinstance(obj_or_cls, LazyLoader):
+        return obj_or_cls.load()
+    else:
+        return obj_or_cls

--- a/src/alma/utils/multiprocessing/lazyload.py
+++ b/src/alma/utils/multiprocessing/lazyload.py
@@ -39,6 +39,24 @@ class LazyLoader:
         return getattr(self.load(), name)
 
 
+def init_lazy_model(obj_or_cls):
+    """
+    Get the original class from a lazy-loaded object or class.
+    
+    Args:
+        obj_or_cls: LazyLoader instance or lazyloaded class
+        
+    Returns:
+        The original class, or the input if it's not lazy-loaded
+    """
+    if isinstance(obj_or_cls, LazyLoader):
+        return obj_or_cls._cls
+    elif hasattr(obj_or_cls, '_original_class'):
+        return obj_or_cls._original_class
+    else:
+        return obj_or_cls
+
+
 def lazyload(cls: Type[T]) -> Type[T]:
     """
     Decorator that makes class instantiation lazy.

--- a/src/alma/utils/multiprocessing/lazyload.py
+++ b/src/alma/utils/multiprocessing/lazyload.py
@@ -1,0 +1,166 @@
+import functools
+from typing import Any, Callable, TypeVar, Type
+
+T = TypeVar("T")
+
+
+class LazyLoader:
+    """A lazy loader that defers object creation until accessed."""
+
+    def __init__(self, cls: Type[T], *args, **kwargs):
+        self._cls = cls
+        self._args = args
+        self._kwargs = kwargs
+        self._instance = None
+        self._loaded = False
+
+    def load(self) -> T:
+        """Load the actual object and return it."""
+        if not self._loaded:
+            self._instance = self._cls(*self._args, **self._kwargs)
+            self._loaded = True
+        return self._instance
+
+    def is_loaded(self) -> bool:
+        """Check if the object has been loaded."""
+        return self._loaded
+
+    def unload(self):
+        """Unload the object to free memory."""
+        self._instance = None
+        self._loaded = False
+
+    def __call__(self, *args, **kwargs):
+        """Allow the lazy loader to be called like the original class."""
+        return self.load()(*args, **kwargs)
+
+    def __getattr__(self, name):
+        """Proxy attribute access to the loaded instance."""
+        return getattr(self.load(), name)
+
+
+def lazyload(cls: Type[T]) -> Type[T]:
+    """
+    Decorator that makes class instantiation lazy.
+
+    Usage:
+        @lazyload
+        model = Model(param1, param2)
+
+        # model is now a LazyLoader, actual Model() is not created yet
+        # When you need the actual model:
+        actual_model = model.load()
+
+        # Or access attributes directly (auto-loads):
+        result = model.some_method()  # This will load Model() first
+    """
+
+    class LazyWrapper:
+        def __new__(cls, *args, **kwargs):
+            return LazyLoader(cls._original_class, *args, **kwargs)
+
+    LazyWrapper._original_class = cls
+    LazyWrapper.__name__ = cls.__name__
+    LazyWrapper.__qualname__ = cls.__qualname__
+
+    return LazyWrapper
+
+
+# Alternative implementation using a metaclass approach
+class LazyMeta(type):
+    """Metaclass that creates lazy-loading classes."""
+
+    def __call__(cls, *args, **kwargs):
+        if hasattr(cls, "_lazy_enabled"):
+            return LazyLoader(cls._original_class, *args, **kwargs)
+        else:
+            return super().__call__(*args, **kwargs)
+
+
+def lazyload_meta(cls: Type[T]) -> Type[T]:
+    """Alternative implementation using metaclass."""
+
+    class LazyClass(cls, metaclass=LazyMeta):
+        _lazy_enabled = True
+        _original_class = cls
+
+    LazyClass.__name__ = cls.__name__
+    LazyClass.__qualname__ = cls.__qualname__
+
+    return LazyClass
+
+
+# Example usage
+if __name__ == "__main__":
+    import time
+
+    # Example model class
+    class Model:
+        def __init__(self, name="default", size=100):
+            print(f"Loading model '{name}' with size {size}... (expensive operation)")
+            time.sleep(0.5)  # Simulate expensive loading
+            self.name = name
+            self.size = size
+            self.data = list(range(size))
+
+        def predict(self, x):
+            return f"Model {self.name} predicts: {x * 2}"
+
+        def __str__(self):
+            return f"Model(name={self.name}, size={self.size})"
+
+    print("=== Without decorator (normal behavior) ===")
+    normal_model = Model("normal", 50)
+    print(f"Normal model: {normal_model}")
+
+    print("\n=== With @lazyload decorator ===")
+
+    @lazyload
+    class Model:
+        def __init__(self, name="default", size=100):
+            print(f"Loading model '{name}' with size {size}... (expensive operation)")
+            time.sleep(0.5)  # Simulate expensive loading
+            self.name = name
+            self.size = size
+            self.data = list(range(size))
+
+        def predict(self, x):
+            return f"Model {self.name} predicts: {x * 2}"
+
+        def __str__(self):
+            return f"Model(name={self.name}, size={self.size})"
+
+    # This looks exactly like normal instantiation, but no loading happens yet
+    model = Model("lazy", 200)
+
+    print(f"Model created (type: {type(model)})")
+    print(f"Is loaded: {model.is_loaded()}")
+
+    print("Accessing model attribute (triggers loading)...")
+    result = model.predict(5)
+    print(f"Prediction result: {result}")
+    print(f"Is loaded: {model.is_loaded()}")
+
+    print("\nManual loading example:")
+
+    @lazyload
+    class AnotherModel:
+        def __init__(self, value):
+            print(f"Actually creating AnotherModel with value {value}")
+            self.value = value
+
+    lazy_model = AnotherModel(42)
+    print(f"Lazy model created, loaded: {lazy_model.is_loaded()}")
+
+    actual_model = lazy_model.load()
+    print(f"Actual model: {actual_model.value}")
+    print(f"Now loaded: {lazy_model.is_loaded()}")
+
+    # For multiprocessing, you can pass the LazyLoader object
+    def worker_function(lazy_obj):
+        # In subprocess, load the actual object
+        obj = lazy_obj.load()
+        return f"Worker processed: {obj}"
+
+    result = worker_function(lazy_model)
+    print(f"Worker result: {result}")

--- a/tests/unit/utils/checks/test_model.py
+++ b/tests/unit/utils/checks/test_model.py
@@ -4,10 +4,8 @@ import pytest
 import torch
 
 from alma.benchmark.benchmark_config import BenchmarkConfig
-from alma.utils.multiprocessing.lazyload import lazyload, LazyLoader
-from alma.utils.checks.model import (
-    check_model,
-)
+from alma.utils.checks.model import check_model
+from alma.utils.multiprocessing.lazyload import LazyLoader, lazyload
 
 
 class DummyModule(torch.nn.Module):

--- a/tests/unit/utils/checks/test_model.py
+++ b/tests/unit/utils/checks/test_model.py
@@ -4,17 +4,10 @@ import pytest
 import torch
 
 from alma.benchmark.benchmark_config import BenchmarkConfig
+from alma.utils.multiprocessing.lazyload import lazyload, LazyLoader
 from alma.utils.checks.model import (
-    check_is_local_function,
     check_model,
-    is_local_function_name,
-    is_picklable,
 )
-
-
-# Helper functions and classes for testing
-def module_level_function(x):
-    return x
 
 
 class DummyModule(torch.nn.Module):
@@ -24,21 +17,6 @@ class DummyModule(torch.nn.Module):
 
     def forward(self, x):
         return self.linear(x)
-
-
-def create_local_function():
-    def local_function(x):
-        return x
-
-    return local_function
-
-
-def return_unpicklable_function():
-    def unpicklable_function():
-        """This function is not picklable as it is locally scoped"""
-        pass
-
-    return unpicklable_function
 
 
 @pytest.fixture
@@ -57,29 +35,30 @@ def test_check_model_with_nn_module(base_config):
         check_model(model, config)
         # Verify warning was logged about memory efficiency
         assert mock_warning.called
-        assert "not memory efficient" in mock_warning.call_args[0][0]
+        assert (
+            "Multiprocessing is enabled, but LazyLoader is not being used."
+            in mock_warning.call_args[0][0]
+        )
 
 
-def test_check_model_with_callable(base_config):
-    """Test check_model with a valid callable."""
+def test_check_model_with_lazyload_with_multiprocessing(base_config):
+    """Test check_model with a lazyload wrapper with multiprocessing."""
     config = base_config.model_copy(update={"multiprocessing": True})
-    check_model(module_level_function, config)  # Should not raise any exceptions
+    model = lazyload(DummyModule())
+    check_model(model, config)  # Should not raise any exceptions
 
 
-def test_check_model_with_local_function(base_config):
-    """Test check_model with a local function (should fail)."""
-    local_func = create_local_function()
-    config = base_config.model_copy(update={"multiprocessing": True})
-
-    with pytest.raises(AssertionError):
-        check_model(local_func, config)
+def test_check_model_with_lazyload_no_multiprocessing(base_config):
+    """Test check_model with a lazyload wrapper without multiprocessing."""
+    model = lazyload(DummyModule())
+    check_model(model, base_config)
 
 
 def test_check_model_with_invalid_type(base_config):
     """Test check_model with invalid type."""
     config = base_config.model_copy(update={"multiprocessing": True})
     with pytest.raises(AssertionError):
-        check_model("not_a_model", config)
+        check_model("not_a_callable", config)
 
 
 def test_check_model_multiprocessing_disabled(base_config):
@@ -89,64 +68,29 @@ def test_check_model_multiprocessing_disabled(base_config):
 
     with patch("logging.Logger.warning") as mock_warning:
         check_model(model, config)
-        # Verify no warning was logged
+        assert mock_warning.called
+
+
+def test_check_model_multiprocessing_enabled(base_config):
+    """Test check_model with multiprocessing enabled."""
+    model = DummyModule()
+    config = base_config.model_copy(update={"multiprocessing": True})
+
+    with patch("logging.Logger.warning") as mock_warning:
+        check_model(model, config)
+        # Verify warning was logged
+        assert mock_warning.called
+
+
+def test_check_model_multiprocessing_and_lazyload_enabled(base_config):
+    """Test check_model with multiprocessing and lazyload enabled."""
+    model = lazyload(DummyModule())
+    config = base_config.model_copy(update={"multiprocessing": True})
+
+    with patch("logging.Logger.warning") as mock_warning:
+        check_model(model, config)
+        # Verify warning no was logged
         assert not mock_warning.called
-
-
-# Tests for check_is_local_function
-def test_check_is_local_function_valid():
-    """Test check_is_local_function with valid function."""
-    check_is_local_function(
-        module_level_function, "error"
-    )  # Should not raise any exceptions
-
-
-def test_check_is_local_function_invalid():
-    """Test check_is_local_function with local function."""
-    local_func = create_local_function()
-    with pytest.raises(AssertionError):
-        check_is_local_function(local_func, "error")
-
-
-def test_check_is_local_function_unpicklable():
-    """Test check_is_local_function with unpicklable function."""
-    with pytest.raises(AssertionError):
-        check_is_local_function(return_unpicklable_function(), "error")
-
-
-# Tests for is_local_function_name
-def test_is_local_function_name_module_level():
-    """Test is_local_function_name with module-level function."""
-    assert not is_local_function_name(module_level_function)
-
-
-def test_is_local_function_name_local():
-    """Test is_local_function_name with local function."""
-    local_func = create_local_function()
-    assert is_local_function_name(local_func)
-
-
-def test_is_local_function_name_invalid_input():
-    """Test is_local_function_name with invalid input."""
-    with pytest.raises(ValueError):
-        is_local_function_name("not_a_function")
-
-
-# Tests for is_picklable
-def test_is_picklable_valid():
-    """Test is_picklable with picklable function."""
-    assert is_picklable(module_level_function)
-
-
-def test_is_picklable_invalid():
-    """Test is_picklable with unpicklable function."""
-    assert not is_picklable(return_unpicklable_function())
-
-
-def test_is_picklable_local():
-    """Test is_picklable with local function."""
-    local_func = create_local_function()
-    assert not is_picklable(local_func)
 
 
 # Test default config behavior

--- a/tests/unit/utils/multiprocessing/test_lazyload.py
+++ b/tests/unit/utils/multiprocessing/test_lazyload.py
@@ -1,0 +1,57 @@
+
+import pytest
+import torch
+import os
+import psutil
+
+from alma.utils.multiprocessing.lazyload import lazyload, LazyLoader, init_lazy_model
+
+
+class Model(torch.nn.Module):
+    def __init__(self, size):
+        super().__init__()
+        self.linear = torch.nn.Linear(size, size, bias=False)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+def get_memory_usage():
+    """Get current memory usage in MB."""
+    process = psutil.Process(os.getpid())
+    return process.memory_info().rss / 1024 / 1024  # Convert to MB
+
+def test_lazy_load_memory_usage():
+    """
+    Test the lazyload function successfully defers increased memory usage until the model
+    is lazy initialised.
+    """
+    # Call create_benchmark_error, which should trigger the decorated benchmark
+    initial_memory = get_memory_usage()
+
+    # We define the model, but because of lazyload we don't yet load it into memory
+    model = lazyload(lambda: Model(5000))
+    assert isinstance(model, LazyLoader), "The model should be a LazyLoader instance"
+    post_def_memory = get_memory_usage()
+    assert post_def_memory < initial_memory + 0.1, "Minimal extra memory should have been consumed by the lazy model init"
+
+    # Initialize the model (i.e. load into memory)
+    model = init_lazy_model(model)
+    post_init_memory = get_memory_usage()
+    assert post_init_memory > initial_memory + 5, "Loading the model into memory should increase the program memory usage"
+
+
+def test_lazy_load_loaded_status():
+    """
+    Test the LazyLoader attributes are as expected.
+    """
+    # We define the model, but because of lazyload we don't yet load it into memory
+    model = lazyload(lambda: Model(5000))
+    assert isinstance(model, LazyLoader), "The model should be a LazyLoader instance"
+    assert not model.is_loaded()
+
+    # Initialize the model (i.e. load into memory)
+    model = init_lazy_model(model)
+    assert not isinstance(model, LazyLoader), "The model should no longer be a LazyLoader instance"
+    assert isinstance(model, Model), "The model should be a Model instance"
+

--- a/tests/unit/utils/multiprocessing/test_lazyload.py
+++ b/tests/unit/utils/multiprocessing/test_lazyload.py
@@ -1,10 +1,10 @@
+import os
 
+import psutil
 import pytest
 import torch
-import os
-import psutil
 
-from alma.utils.multiprocessing.lazyload import lazyload, LazyLoader, init_lazy_model
+from alma.utils.multiprocessing.lazyload import LazyLoader, init_lazy_model, lazyload
 
 
 class Model(torch.nn.Module):
@@ -21,6 +21,7 @@ def get_memory_usage():
     process = psutil.Process(os.getpid())
     return process.memory_info().rss / 1024 / 1024  # Convert to MB
 
+
 def test_lazy_load_memory_usage():
     """
     Test the lazyload function successfully defers increased memory usage until the model
@@ -33,12 +34,16 @@ def test_lazy_load_memory_usage():
     model = lazyload(lambda: Model(5000))
     assert isinstance(model, LazyLoader), "The model should be a LazyLoader instance"
     post_def_memory = get_memory_usage()
-    assert post_def_memory < initial_memory + 0.1, "Minimal extra memory should have been consumed by the lazy model init"
+    assert (
+        post_def_memory < initial_memory + 0.1
+    ), "Minimal extra memory should have been consumed by the lazy model init"
 
     # Initialize the model (i.e. load into memory)
     model = init_lazy_model(model)
     post_init_memory = get_memory_usage()
-    assert post_init_memory > initial_memory + 5, "Loading the model into memory should increase the program memory usage"
+    assert (
+        post_init_memory > initial_memory + 5
+    ), "Loading the model into memory should increase the program memory usage"
 
 
 def test_lazy_load_loaded_status():
@@ -52,6 +57,7 @@ def test_lazy_load_loaded_status():
 
     # Initialize the model (i.e. load into memory)
     model = init_lazy_model(model)
-    assert not isinstance(model, LazyLoader), "The model should no longer be a LazyLoader instance"
+    assert not isinstance(
+        model, LazyLoader
+    ), "The model should no longer be a LazyLoader instance"
     assert isinstance(model, Model), "The model should be a Model instance"
-


### PR DESCRIPTION
In our comparison of conversion options, unfortunately some options (e.g. optimum quanto) can pollute the global torch state, breaking other options. To get around this, we have the option to use multiprocessing to spin up a subprocess for each option. However,m this causes the risk of the model being loaed into memory twice: one in the parent script, e.g.
```python
model = Net()

# Do benchmarking
```
and again in the child process, where the model weights get copied over.

The previous solution was to encourage users to wrap the model initialization in a callable which deferred the initialization until the child process. However, this was ugly and caused some problems elsewhere in the codebase, as models are also Callables, and so it was hard to tell when an object was a wrapper and when it was the actual model.

This PR updates the defer-initialization to be done via a `lazyload` function, which makes everything cleaner and is also easier for the user, IMO. E.g.
```python
model = lazyload(Net)
```

or (if parameters need to be fed to the model initialisation)
```python
model = lazyload(
    lambda: torch.nn.Sequentiala,
        torch.nn.Linear(3, 3),
        torch.nn.ReLU(),       
    )
)

```

If multiprocessing is enabled and lazyload is not used, it will log a warning.